### PR TITLE
fix: handle when no res is available from mixpanel request

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -24,14 +24,14 @@ const sendRequest = (secret, script, params) => new Promise((resolve, reject) =>
     .send({ script, params })
     .accept('application/json')
     .end((err, res) => {
-      if (res.body && res.body.error) {
+      if (res && res.body && res.body.error) {
         err = new Error('Mixpanel Error: ' + res.body.error);
         err.status = res.status;
       }
       if (err) {
         return reject(err);
       }
-      resolve(res.body);
+      resolve(res && res.body);
     });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mixpanel-jql",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "lib/client.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
This will fix backhouse crashes that have been happening for 5 days: https://wlist.slack.com/archives/C2LLGH58F/p1592226051215600?thread_ts=1592222249.214600&cid=C2LLGH58F